### PR TITLE
敵の色ごとに状態遷移を変更、逃走処理実装

### DIFF
--- a/Source/GhostBurster/Private/Enemy/BlueEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/BlueEnemy.cpp
@@ -135,8 +135,7 @@ void ABlueEnemy::Think()
 	{
 	case EState::Wait:	//‘Ò‹@
 		if (MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Move; }	// ˆÚ“®‚Ö
-		if (Status.HP <= 0 || 
-			FleeUpToCount == FleeUpToCountNumber && MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Die; }	// Ž€–S‚Ö
+		if (Status.HP <= 0 || FleeUpToCount == FleeUpToCountNumber) { NowState = EState::Die; }	// Ž€–S‚Ö
 		break;
 
 	case EState::Move:	//ˆÚ“®

--- a/Source/GhostBurster/Private/Enemy/BlueEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/BlueEnemy.cpp
@@ -7,6 +7,9 @@
 #include "Kismet/GameplayStatics.h"
 
 ABlueEnemy::ABlueEnemy()
+	:
+	//ó‘Ô‘JˆÚŠÖŒW
+	FleeUpToCount(0), FleeUpToCountNumber(3)
 {
 	PrimaryActorTick.bCanEverTick = true;
 
@@ -99,6 +102,7 @@ void ABlueEnemy::BeginPlay()
 		//‰ŠúƒIƒpƒVƒeƒB’l‚ğİ’è
 		this->DynamicMaterial_Eye->SetScalarParameterValue(FName("Opacity"), this->OpacityValue);
 	}
+
 }
 
 void ABlueEnemy::Tick(float DeltaTime)
@@ -130,8 +134,9 @@ void ABlueEnemy::Think()
 	switch (NowState)
 	{
 	case EState::Wait:	//‘Ò‹@
-		if (MoveCount >= AttackUpToTime * Gamefps) { NowState = EState::Attack; }	// UŒ‚‚Ö
-		if (Status.HP <= 0) { NowState = EState::Die; }								// €–S‚Ö
+		if (MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Move; }	// ˆÚ“®‚Ö
+		if (Status.HP <= 0 || 
+			FleeUpToCount == FleeUpToCountNumber && MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Die; }	// €–S‚Ö
 		break;
 
 	case EState::Move:	//ˆÚ“®
@@ -139,10 +144,10 @@ void ABlueEnemy::Think()
 		if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
 		break;
 
-	case EState::Attack:	//UŒ‚
-		if (this->bHasEndedAttack) { NowState = EState::Wait; }	// ‘Ò‹@‚Ö
-		if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
-		break;
+	//case EState::Attack:	//UŒ‚
+	//	if (this->bHasEndedAttack) { NowState = EState::Wait; }	// ‘Ò‹@‚Ö
+	//	if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
+	//	break;
 
 	case EState::Appear:	//oŒ»
 		if (this->bHasEndedAppear) { NowState = EState::Move; }	// ˆÚ“®‚Ö
@@ -177,6 +182,12 @@ void ABlueEnemy::ActProcess()
 		break;
 
 	case EState::Die:		//€–S
+		//“¦‘–‚µ‚½‚©
+		if (FleeUpToCount == FleeUpToCountNumber)
+		{
+			this->bIsEscaped = true;
+		}
+
 		EnemyDead();
 		break;
 
@@ -245,6 +256,9 @@ void ABlueEnemy::ProcessJustForFirst_Move()
 			//ˆÚ“®‰ñ”‚ğ‘‚â‚·
 			this->MovingTimesCount++;
 		}
+
+		//“¦‚°‚é‚Ü‚Å‚ÌƒJƒEƒ“ƒg‚ğ‘‚â‚·
+		FleeUpToCount++;
 	}
 
 	//•¡”‰ñˆ—‚ªs‚í‚ê‚È‚¢‚æ‚¤‚É‚·‚é

--- a/Source/GhostBurster/Private/Enemy/BossEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/BossEnemy.cpp
@@ -116,7 +116,7 @@ void ABossEnemy::ActProcess()
 		break;
 
 	case EState::Attack:	//攻撃
-		if (MoveCount == AttackUpToTime * Gamefps / 60) //15の部分は攻撃モーションに合わせて変更する
+		if (MoveCount == TimeFromWaitToStateTransition * Gamefps / 60) //15の部分は攻撃モーションに合わせて変更する
 		{
 			//攻撃する
 			UKismetSystemLibrary::PrintString(this, TEXT("BossEnemy Attack!"), true, true, FColor::Yellow, 2.f, TEXT("None"));

--- a/Source/GhostBurster/Private/Enemy/GreenEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/GreenEnemy.cpp
@@ -99,6 +99,7 @@ void AGreenEnemy::BeginPlay()
 		//初期オパシティ値を設定
 		this->DynamicMaterial_Eye->SetScalarParameterValue(FName("Opacity"), this->OpacityValue);
 	}
+
 }
 
 void AGreenEnemy::Tick(float DeltaTime)
@@ -130,8 +131,8 @@ void AGreenEnemy::Think()
 	switch (NowState)
 	{
 	case EState::Wait:	//待機
-		if (MoveCount >= AttackUpToTime * Gamefps) { NowState = EState::Attack; }	// 攻撃へ
-		if (Status.HP <= 0) { NowState = EState::Die; }					// 死亡へ
+		if (MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Attack; }	// 攻撃へ
+		if (Status.HP <= 0) { NowState = EState::Die; }												// 死亡へ
 		break;
 
 	case EState::Move:	//移動

--- a/Source/GhostBurster/Private/Enemy/NormalEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/NormalEnemy.cpp
@@ -138,8 +138,8 @@ void ANormalEnemy::Think()
 	switch (NowState)
 	{
 	case EState::Wait:	//‘Ò‹@
-		if (MoveCount >= AttackUpToTime * Gamefps) { NowState = EState::Attack; }	// UŒ‚‚Ö
-		if (Status.HP <= 0) { NowState = EState::Die; }								// €–S‚Ö
+		if (MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Move; }	// ˆÚ“®‚Ö
+		if (Status.HP <= 0) { NowState = EState::Die; }											// €–S‚Ö
 		break;
 
 	case EState::Move:	//ˆÚ“®
@@ -147,10 +147,10 @@ void ANormalEnemy::Think()
 		if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
 		break;
 
-	case EState::Attack:	//UŒ‚
-		if (this->bHasEndedAttack) { NowState = EState::Wait; }	// ‘Ò‹@‚Ö
-		if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
-		break;
+	//case EState::Attack:	//UŒ‚
+	//	if (this->bHasEndedAttack) { NowState = EState::Wait; }	// ‘Ò‹@‚Ö
+	//	if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
+	//	break;
 
 	case EState::Appear:	//oŒ»
 		if (this->bHasEndedAppear) { NowState = EState::Move; }	// ˆÚ“®‚Ö

--- a/Source/GhostBurster/Private/Enemy/RedEnemy.cpp
+++ b/Source/GhostBurster/Private/Enemy/RedEnemy.cpp
@@ -130,8 +130,8 @@ void ARedEnemy::Think()
 	switch (NowState)
 	{
 	case EState::Wait:	//‘Ò‹@
-		if (MoveCount >= AttackUpToTime * Gamefps) { NowState = EState::Attack; }	// UŒ‚‚Ö
-		if (Status.HP <= 0) { NowState = EState::Die; }				// €–S‚Ö
+		if (MoveCount >= TimeFromWaitToStateTransition * Gamefps) { NowState = EState::Attack; }	// UŒ‚‚Ö
+		if (Status.HP <= 0) { NowState = EState::Die; }												// €–S‚Ö
 		break;
 
 	case EState::Move:	//ˆÚ“®
@@ -140,7 +140,7 @@ void ARedEnemy::Think()
 		break;
 
 	case EState::Attack:	//UŒ‚
-		if (this->bHasEndedAttack) { NowState = EState::Wait; }	// ‘Ò‹@‚Ö
+		if (this->bHasEndedAttack) { NowState = EState::Move; }	// ˆÚ“®‚Ö
 		if (Status.HP <= 0) { NowState = EState::Die; }			// €–S‚Ö
 		break;
 

--- a/Source/GhostBurster/Public/Enemy/BlueEnemy.h
+++ b/Source/GhostBurster/Public/Enemy/BlueEnemy.h
@@ -19,17 +19,22 @@ class GHOSTBURSTER_API ABlueEnemy : public AEnemys
 	//Tickでの処理
 	virtual void TickProcess() override;
 	
-	//エネミーの状態判断
-	virtual void Think() override;
-
-	//状態に基づいた動きをする
-	virtual void ActProcess() override;
+	//状態遷移関係-----------------------------------------------------------------------------------------------------------------
+	//☆変数
+	int				FleeUpToCount;			// 逃げるまでのカウント
+	int				FleeUpToCountNumber;	// 逃げるまでに必要なカウントの数
+	
+	//☆関数
+	virtual void	Think() override;		// エネミーの状態判断
+	virtual void	ActProcess() override;	// 状態に基づいた動きをする
 
 	//移動関係---------------------------------------------------------------------------------------------------------------------
+	//☆関数
 	virtual void ProcessJustForFirst_Move() override;	// 状態Move遷移時にのみ行う処理
 	virtual bool Move() override;						// 移動処理
 
 	//攻撃関係---------------------------------------------------------------------------------------------------------------------
+	//☆関数
 	virtual bool Attack() override;	// 攻撃処理
 
 protected:

--- a/Source/GhostBurster/Public/Enemy/Enemys.h
+++ b/Source/GhostBurster/Public/Enemy/Enemys.h
@@ -56,25 +56,20 @@ protected:
 		Blue = 3,
 	};
 
-	//☆変数
-	//敵の行動制御用のカウント
-	int MoveCount;
-
-	//一度だけ行う処理をしたか
-	bool bOnceDoProcessBeenIs;
-
 	//☆関数
 	//Tickでの処理
 	virtual void TickProcess() PURE_VIRTUAL(AEnemys::TickProcess, );
 
-	//エネミーの状態判断
-	virtual void Think() PURE_VIRTUAL(AEnemys::Think, );
+	//状態遷移関係-----------------------------------------------------------------------------------------------------------------
+	//☆変数
+	int				MoveCount;											// 敵の行動制御用のカウント
+	bool			bOnceDoProcessBeenIs;								// 一度だけ行う処理をしたか
+	float			TimeFromWaitToStateTransition;						// 待機から状態遷移するまでの時間
 
-	//状態の更新
-	void UpdateState(EState NowState);
-
-	//状態に基づいた動きをする
-	virtual void ActProcess() PURE_VIRTUAL(AEnemys::ActProcess, );
+	//☆関数
+	virtual void	Think() PURE_VIRTUAL(AEnemys::Think, );				// エネミーの状態判断
+	void			UpdateState(EState NowState);						// 状態の更新
+	virtual void	ActProcess() PURE_VIRTUAL(AEnemys::ActProcess, );	// 状態に基づいた動きをする
 
 	//FPS関係----------------------------------------------------------------------------------------------------------------------
 	//☆変数
@@ -141,25 +136,26 @@ protected:
 	//攻撃関係---------------------------------------------------------------------------------------------------------------------
 	//☆変数
 	bool	bHasEndedAttack;											// 攻撃が終了したか
-	float	AttackUpToTime;												// ゴーストの攻撃までの時間(秒)
 
 	//☆関数
 	virtual bool Attack() PURE_VIRTUAL(AEnemys::Move, return false;);	// 攻撃処理
 
 	//死亡関係---------------------------------------------------------------------------------------------------------------------
 	//☆変数
-	bool bIsDestroy;	// 徐々に透明にする処理を終了するか
+	bool	bIsDestroy;					// 徐々に透明にする処理を終了するか
+	float	TimeUpToTransparency;		// 透明になるまでの時間(秒)
+	bool	bIsEscaped;					// 逃走したか
 
 	//☆関数
-	void EnemyDead();				// HPが0になったら消滅させる
-	void ProcessDoOnce_EnemyDead();	// EnemyDeadで一度だけ行う処理
-	bool Transparentize_Dead();		// 死亡時の徐々に透明にする処理
+	void	EnemyDead();				// HPが0になったら消滅させる
+	void	ProcessDoOnce_EnemyDead();	// EnemyDeadで一度だけ行う処理
+	bool	Transparentize_Dead();		// 死亡時の徐々に透明にする処理
 
 	//出現関係---------------------------------------------------------------------------------------------------------------------
 	//☆変数 
 	bool	bHasEndedAppear;	// 出現が終了したか
 	float	OpacityValue;		// オパシティの値
-	int		TimeSpentInAppear;	// 出現するのにかかる時間
+	int		TimeSpentInAppear;	// 出現するのにかかる時間(秒)
 	float	MaxOpacity;			// オパシティの最大値(0～1の範囲)
 
 	//☆関数
@@ -179,10 +175,10 @@ public:
 
 	//Setter関数-------------------------------------------------------------------------------------------------------------------
 	void SetHP(const int HPValue);								// HPの設定用関数
-	void SetAttackUpToTime(const float SetTime);				// 攻撃状態になるまでの時間設定用関数
+	void SetTimeFromWaitToStateTransition(const float SetTime);	// 攻撃状態になるまでの時間設定用関数
 	void SetGoalLocations(const TArray<FVector>& SetLocations);	// 目標座標の設定用関数
 	void SetMoveTime(const float SetTime);						// 移動時間の設定用
 	UFUNCTION(BlueprintCallable, Category = "Enemy")
-	void SetInitialData(const int HP, const float AttackUpToTimeValue, const TArray<FVector>& SetLocations, const float MoveTimeValue);	// 生成されたときの設定用関数
-	virtual bool CheckPlayerLightColor(EFlashlight_Color PlayerColor) const PURE_VIRTUAL(AEnemys::GetEnemyColor, return false;);		// プレイヤーのライトの色と敵のライトの色をチェックする関数
+	void SetInitialData(const int HP, const float SetTime, const TArray<FVector>& SetLocations, const float MoveTimeValue);			// 生成されたときの設定用関数
+	virtual bool CheckPlayerLightColor(EFlashlight_Color PlayerColor) const PURE_VIRTUAL(AEnemys::GetEnemyColor, return false;);	// プレイヤーのライトの色と敵のライトの色をチェックする関数
 };

--- a/Source/GhostBurster/Public/Enemy/GreenEnemy.h
+++ b/Source/GhostBurster/Public/Enemy/GreenEnemy.h
@@ -19,17 +19,18 @@ class GHOSTBURSTER_API AGreenEnemy : public AEnemys
 	//Tick‚Å‚Ìˆ—
 	virtual void TickProcess() override;
 	
-	//ƒGƒlƒ~[‚Ìó‘Ô”»’f
-	virtual void Think() override;
-
-	//ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
-	virtual void ActProcess() override;
+	//ó‘Ô‘JˆÚŠÖŒW-----------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
+	virtual void Think() override;		// ƒGƒlƒ~[‚Ìó‘Ô”»’f
+	virtual void ActProcess() override;	// ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
 
 	//ˆÚ“®ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual void ProcessJustForFirst_Move() override;	// ó‘ÔMove‘JˆÚ‚É‚Ì‚İs‚¤ˆ—
 	virtual bool Move() override;						// ˆÚ“®ˆ—
 
 	//UŒ‚ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual bool Attack() override;	// UŒ‚ˆ—
 
 protected:

--- a/Source/GhostBurster/Public/Enemy/NormalEnemy.h
+++ b/Source/GhostBurster/Public/Enemy/NormalEnemy.h
@@ -16,17 +16,18 @@ class GHOSTBURSTER_API ANormalEnemy : public AEnemys
 	//Tick‚Å‚Ìˆ—
 	virtual void TickProcess() override;
 	
-	//ƒGƒlƒ~[‚Ìó‘Ô”»’f
-	virtual void Think() override;
-
-	//ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
-	virtual void ActProcess() override;
+	//ó‘Ô‘JˆÚŠÖŒW-----------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
+	virtual void Think() override;		// ƒGƒlƒ~[‚Ìó‘Ô”»’f
+	virtual void ActProcess() override;	// ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
 
 	//ˆÚ“®ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual void ProcessJustForFirst_Move() override;	// ó‘ÔMove‘JˆÚ‚É‚Ì‚İs‚¤ˆ—
 	virtual bool Move() override;						// ˆÚ“®ˆ—
 
 	//UŒ‚ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual bool Attack() override;						// UŒ‚ˆ—
 
 protected:

--- a/Source/GhostBurster/Public/Enemy/RedEnemy.h
+++ b/Source/GhostBurster/Public/Enemy/RedEnemy.h
@@ -19,17 +19,18 @@ class GHOSTBURSTER_API ARedEnemy : public AEnemys
 	//Tick‚Å‚Ìˆ—
 	virtual void TickProcess() override;
 	
-	//ƒGƒlƒ~[‚Ìó‘Ô”»’f
-	virtual void Think() override;
-
-	//ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
-	virtual void ActProcess() override;
+	//ó‘Ô‘JˆÚŠÖŒW-----------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
+	virtual void Think() override;		// ƒGƒlƒ~[‚Ìó‘Ô”»’f
+	virtual void ActProcess() override;	// ó‘Ô‚ÉŠî‚Ã‚¢‚½“®‚«‚ğ‚·‚é
 
 	//ˆÚ“®ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual void ProcessJustForFirst_Move() override;	// ó‘ÔMove‘JˆÚ‚É‚Ì‚İs‚¤ˆ—
 	virtual bool Move() override;						// ˆÚ“®ˆ—
 
 	//UŒ‚ŠÖŒW---------------------------------------------------------------------------------------------------------------------
+	//™ŠÖ”
 	virtual bool Attack() override;	// UŒ‚ˆ—
 
 protected:


### PR DESCRIPTION
変更
・白い敵は出現後、移動と待機をループするように変更
・緑の敵は出現後移動して、その後待機、攻撃をループするよう変更
・赤の敵は出現後、移動→待機→攻撃をループするよう変更
・青の敵は出現後、移動と待機をループし、3回目の移動の後、逃走(死亡状態)に遷移するよう変更